### PR TITLE
allow relative urls

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,4 @@
+// jest.config.js
+module.exports = {
+    testURL: "http://localhost/"
+  };

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "node": ">=8.5.0"
   },
   "dependencies": {
+    "url-parse": "^1.4.3",
     "whatwg-fetch": "^2.0.4",
     "winston": "2.4.0"
   },

--- a/src/services/authService.js
+++ b/src/services/authService.js
@@ -67,7 +67,7 @@ export default class AuthService {
     // TODO password salt
     // console.log("WIP", `AuthService.requestAccessToken
     // ${username}${password} ${this.client.url}`);
-    const url = this.urlBuilder.createUrl(`access_token/`);
+    const url = this.urlBuilder.createUrl("access_token/");
     const that = this;
 
     const body = {

--- a/src/services/authService.js
+++ b/src/services/authService.js
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 import "whatwg-fetch";
+import UrlBuilder from "../utils/urlBuilder";
 
 export default class AuthService {
   constructor(client) {
@@ -19,6 +20,7 @@ export default class AuthService {
       throw new Error("AuthClient not configured");
     }
     this.client = { ...client };
+    this.urlBuilder = new UrlBuilder(client.url);
     this.resetAttributes();
     this.needToLoad = true;
   }
@@ -65,7 +67,7 @@ export default class AuthService {
     // TODO password salt
     // console.log("WIP", `AuthService.requestAccessToken
     // ${username}${password} ${this.client.url}`);
-    const url = this.buildUrl(`${this.client.url}access_token`);
+    const url = this.urlBuilder.createUrl(`access_token/`);
     const that = this;
 
     const body = {
@@ -131,29 +133,16 @@ export default class AuthService {
     window.localStorage.removeItem("scope");
   }
 
-  buildUrl(url, protocol) {
-    const p = this.getProtocol(protocol);
-    return `${p}://${url}`;
-  }
-
-  getProtocol(protocol = "http") {
-    let p = protocol;
-    if (this.client.secure) {
-      p += "s";
-    }
-    return p;
-  }
-
-  buildAuthUrl(url, protocol) {
+  buildAuthUrl(url) {
     if (this.isAuthenticated()) {
       let n = "?access_token=";
       if (url.indexOf("?") > -1) {
         n = "&access_token=";
       }
 
-      return this.buildUrl(url, protocol) + n + this.accessToken;
+      return url + n + this.accessToken;
     }
     // TODO check if auth is ok
-    return this.buildUrl(url, protocol);
+    return url;
   }
 }

--- a/src/services/webService.js
+++ b/src/services/webService.js
@@ -6,6 +6,8 @@
  */
 import "whatwg-fetch";
 
+import UrlBuilder from "../utils/urlBuilder";
+
 export default class WebService {
   constructor(client, authService) {
     if (client && client.provider) {
@@ -13,24 +15,25 @@ export default class WebService {
     } else if (!client || !client.url) {
       throw new Error("WebClient not configured");
     }
+    this.urlBuilder = new UrlBuilder(client.url);
     this.client = { ...client };
     this.authService = authService;
   }
 
-  createUrl(route) {
-    const url = this.client.url + route;
-    return url;
+  buildHttpUrl(route) {
+    const url = this.urlBuilder.createUrl(route);
+    return this.authService.buildAuthUrl(url.href);
   }
 
-  buildUrl(route, protocol = "http") {
-    const url = this.createUrl(route);
-    return this.authService.buildAuthUrl(url, protocol);
+  buildWsUrl(route) {
+    const url = this.urlBuilder.createWsUrl(route);
+    return this.authService.buildAuthUrl(url.href);
   }
 
   send(route, data, method, auth) {
     const isAuth = this.authService.isAuthenticated();
     const clientId = this.authService.getClientId();
-    const url = this.buildUrl(route);
+    const url = this.buildHttpUrl(route);
 
     if (!isAuth && auth) {
       Promise.reject(new Error("not authenticated"));

--- a/src/utils/urlBuilder.js
+++ b/src/utils/urlBuilder.js
@@ -1,24 +1,22 @@
-import Url from 'url-parse';
+import Url from "url-parse";
 
 export default class UrlBuilder {
-    
-    constructor(clientUrl){
-        this.clientUrl = clientUrl;
-    }
+  constructor(clientUrl) {
+    this.clientUrl = clientUrl;
+  }
 
-    createUrl(route) {
-        const url = new Url(route, this.clientUrl);
-        if (url.origin != "null") {
-            return url;
-        } else {
-            const base = new Url(this.clientUrl, window.location.href);
-            return new Url(route, base.href);
-        }
+  createUrl(route) {
+    const url = new Url(route, this.clientUrl);
+    if (url.origin !== "null") {
+      return url;
     }
-    
-    createWsUrl(route) {
-        const url = this.createUrl(route);
-        url.set('protocol', url.protocol === "https:" ? "wss:" : "ws:")
-        return url;
-    }
+    const base = new Url(this.clientUrl, window.location.href);
+    return new Url(route, base.href);
+  }
+
+  createWsUrl(route) {
+    const url = this.createUrl(route);
+    url.set("protocol", url.protocol === "https:" ? "wss:" : "ws:");
+    return url;
+  }
 }

--- a/src/utils/urlBuilder.js
+++ b/src/utils/urlBuilder.js
@@ -1,0 +1,24 @@
+import Url from 'url-parse';
+
+export default class UrlBuilder {
+    
+    constructor(clientUrl){
+        this.clientUrl = clientUrl;
+    }
+
+    createUrl(route) {
+        const url = new Url(route, this.clientUrl);
+        if (url.origin != "null") {
+            return url;
+        } else {
+            const base = new Url(this.clientUrl, window.location.href);
+            return new Url(route, base.href);
+        }
+    }
+    
+    createWsUrl(route) {
+        const url = this.createUrl(route);
+        url.set('protocol', url.protocol === "https:" ? "wss:" : "ws:")
+        return url;
+    }
+}

--- a/tests/utils/urlBuilder.test.js
+++ b/tests/utils/urlBuilder.test.js
@@ -1,0 +1,137 @@
+import UrlBuilder from "../../src/utils/urlBuilder";
+
+/**
+ * Copyright (c) 2015-present, CWB SAS
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+describe("api url tests", () => {
+  beforeAll(() => {
+    const windowLocation = JSON.stringify(window.location);
+    delete window.location;
+    Object.defineProperty(window, 'location', {
+      writable: true,
+      value: JSON.parse(windowLocation)
+    });
+  })
+
+  function setWindowLocation(url) {
+    Object.defineProperty(window.location, 'href', {
+      writable: true,
+      value: url
+    });
+  }
+
+  it("setting full path", async () => {
+    const conf = { url: "http://localhost/api/v1/" };
+    const urlBuilder = new UrlBuilder(conf.url);
+    expect(urlBuilder.createUrl("admin/languages").href).toEqual("http://localhost/api/v1/admin/languages");
+  });
+
+  it("setting full path with port", async () => {
+    const conf = { url: "http://localhost:8080/api/v1/" };
+    const urlBuilder = new UrlBuilder(conf.url);
+    expect(urlBuilder.createUrl("admin/languages").href).toEqual("http://localhost:8080/api/v1/admin/languages");
+  });
+
+  it("https", async () => {
+    const conf = { url: "http://localhost:8080/api/v1/" };
+    const urlBuilder = new UrlBuilder(conf.url);
+    expect(urlBuilder.createUrl("admin/languages").href).toEqual("http://localhost:8080/api/v1/admin/languages");
+  });
+
+  it("http relative", async () => {
+    setWindowLocation('http://n7d7s8zez7.ngrok.io')
+    const conf = { url: "/api/v1/" };
+    const urlBuilder = new UrlBuilder(conf.url);
+    expect(urlBuilder.createUrl("admin").href).toEqual("http://n7d7s8zez7.ngrok.io/api/v1/admin");
+    expect(urlBuilder.createUrl("/root").href).toEqual("http://n7d7s8zez7.ngrok.io/root");
+    expect(urlBuilder.createUrl("/").href).toEqual("http://n7d7s8zez7.ngrok.io/");
+  });
+
+  it("http relative", async () => {
+    setWindowLocation('http://n7d7s8zez7.ngrok.io/')
+    const conf = { url: "/api/v1/" };
+    const urlBuilder = new UrlBuilder(conf.url);
+    expect(urlBuilder.createUrl("admin").href).toEqual("http://n7d7s8zez7.ngrok.io/api/v1/admin");
+    expect(urlBuilder.createUrl("/root").href).toEqual("http://n7d7s8zez7.ngrok.io/root");
+    expect(urlBuilder.createUrl("/").href).toEqual("http://n7d7s8zez7.ngrok.io/");
+  });
+
+  it("https relative", async () => {
+    setWindowLocation('https://n7d7s8zez7.ngrok.io/')
+    const conf = { url: "/api/v1/" };
+    const urlBuilder = new UrlBuilder(conf.url);
+    expect(urlBuilder.createUrl("admin").href).toEqual("https://n7d7s8zez7.ngrok.io/api/v1/admin");
+    expect(urlBuilder.createUrl("/root").href).toEqual("https://n7d7s8zez7.ngrok.io/root");
+    expect(urlBuilder.createUrl("/").href).toEqual("https://n7d7s8zez7.ngrok.io/");
+  });
+
+  it("https relative", async () => {
+    setWindowLocation('https://n7d7s8zez7.ngrok.io/')
+    const conf = { url: "/api/v1/" };
+    const urlBuilder = new UrlBuilder(conf.url);
+    expect(urlBuilder.createUrl("admin").href).toEqual("https://n7d7s8zez7.ngrok.io/api/v1/admin");
+    expect(urlBuilder.createUrl("/root").href).toEqual("https://n7d7s8zez7.ngrok.io/root");
+    expect(urlBuilder.createUrl("/").href).toEqual("https://n7d7s8zez7.ngrok.io/");
+  });
+
+  it("https absolute", async () => {
+    setWindowLocation('http://n7d7s8zez7.ngrok.io/')
+    const conf = { url: "https://n7d7s8zez7.ngrok.io/api/v1/" };
+    const urlBuilder = new UrlBuilder(conf.url);
+    expect(urlBuilder.createUrl("admin").href).toEqual("https://n7d7s8zez7.ngrok.io/api/v1/admin");
+    expect(urlBuilder.createUrl("/root").href).toEqual("https://n7d7s8zez7.ngrok.io/root");
+    expect(urlBuilder.createUrl("/").href).toEqual("https://n7d7s8zez7.ngrok.io/");
+  });
+
+  it("http relative with nested window location", async () => {
+    setWindowLocation('http://n7d7s8zez7.ngrok.io/a/b/c')
+    const conf = { url: "/api/v1/" };
+    const urlBuilder = new UrlBuilder(conf.url);
+    expect(urlBuilder.createUrl("admin").href).toEqual("http://n7d7s8zez7.ngrok.io/api/v1/admin");
+    expect(urlBuilder.createUrl("/root").href).toEqual("http://n7d7s8zez7.ngrok.io/root");
+    expect(urlBuilder.createUrl("/").href).toEqual("http://n7d7s8zez7.ngrok.io/");
+  });
+
+  it("https absolute localhost", async () => {
+    setWindowLocation('http://localhost/')
+    const conf = { url: "https://n7d7s8zez7.ngrok.io/api/v1/" };
+    const urlBuilder = new UrlBuilder(conf.url);
+    expect(urlBuilder.createUrl("admin").href).toEqual("https://n7d7s8zez7.ngrok.io/api/v1/admin");
+    expect(urlBuilder.createUrl("/root").href).toEqual("https://n7d7s8zez7.ngrok.io/root");
+    expect(urlBuilder.createUrl("/").href).toEqual("https://n7d7s8zez7.ngrok.io/");
+  });
+
+  it("defaults to http when no protocol given", async () => {
+    setWindowLocation('http://localhost/')
+    const conf = { url: "//n7d7s8zez7.ngrok.io/api/v1/" };
+    const urlBuilder = new UrlBuilder(conf.url);
+    expect(urlBuilder.createUrl("admin").href).toEqual("http://n7d7s8zez7.ngrok.io/api/v1/admin");
+    expect(urlBuilder.createUrl("/root").href).toEqual("http://n7d7s8zez7.ngrok.io/root");
+    expect(urlBuilder.createUrl("/").href).toEqual("http://n7d7s8zez7.ngrok.io/");
+    expect(urlBuilder.createWsUrl("admin").href).toEqual("ws://n7d7s8zez7.ngrok.io/api/v1/admin");
+    expect(urlBuilder.createWsUrl("/root").href).toEqual("ws://n7d7s8zez7.ngrok.io/root");
+    expect(urlBuilder.createWsUrl("/").href).toEqual("ws://n7d7s8zez7.ngrok.io/");
+  });
+
+  it("ws relative", async () => {
+    setWindowLocation('http://n7d7s8zez7.ngrok.io/')
+    const conf = { url: "/api/v1/" };
+    const urlBuilder = new UrlBuilder(conf.url);
+    expect(urlBuilder.createWsUrl("admin").href).toEqual("ws://n7d7s8zez7.ngrok.io/api/v1/admin");
+    expect(urlBuilder.createWsUrl("/root").href).toEqual("ws://n7d7s8zez7.ngrok.io/root");
+    expect(urlBuilder.createWsUrl("/").href).toEqual("ws://n7d7s8zez7.ngrok.io/");
+  });
+
+  it("wss absolute", async () => {
+    setWindowLocation('http://localhost/')
+    const conf = { url: "https://n7d7s8zez7.ngrok.io/api/v1/" };
+    const urlBuilder = new UrlBuilder(conf.url);
+    expect(urlBuilder.createWsUrl("admin").href).toEqual("wss://n7d7s8zez7.ngrok.io/api/v1/admin");
+    expect(urlBuilder.createWsUrl("/root").href).toEqual("wss://n7d7s8zez7.ngrok.io/root");
+    expect(urlBuilder.createWsUrl("/").href).toEqual("wss://n7d7s8zez7.ngrok.io/");
+  });
+});


### PR DESCRIPTION
These are changes to allow us to use relative URLs in ZoApp-based apps.

Simplifies definition of api urls. Now only a `host` needs to be given to AuthService and WebService. If nothing is given, all paths get resolved from the `window.location` (in most of our use cases, it is the case that frontend and api are hosted on the same host, with different paths).

See the tests for details.

With those changes, in zoapp-front, in the scenario of one host for both front and api, we don't need anymore to set the protocol, host, etc. in the frontend. It also allows to use ngrok to share a running version of opla on a machine (frontend will query `${window.location}/api/v1` by default).