### PR TITLE
Add scope verification before reset access

### DIFF
--- a/tests/services/webService.test.js
+++ b/tests/services/webService.test.js
@@ -18,7 +18,7 @@ describe("webService", () => {
     it("should return valid data", async () => {
       AuthService.mockImplementation(() => ({
         isAuthenticated: () => true,
-        buildAuthUrl: url => url,
+        buildAuthUrl: (url) => url,
         getClientId: () => 42,
       }));
 
@@ -31,7 +31,7 @@ describe("webService", () => {
     it("should throw an error if status is different than 200", async () => {
       AuthService.mockImplementation(() => ({
         isAuthenticated: () => true,
-        buildAuthUrl: url => url,
+        buildAuthUrl: (url) => url,
         getClientId: () => 42,
       }));
 
@@ -50,7 +50,7 @@ describe("webService", () => {
     it("should create a valid post request", async () => {
       AuthService.mockImplementation(() => ({
         isAuthenticated: () => true,
-        buildAuthUrl: url => url,
+        buildAuthUrl: (url) => url,
         getClientId: () => 42,
       }));
 
@@ -72,7 +72,7 @@ describe("webService", () => {
     it("should create a valid put request", async () => {
       AuthService.mockImplementation(() => ({
         isAuthenticated: () => true,
-        buildAuthUrl: url => url,
+        buildAuthUrl: (url) => url,
         getClientId: () => 42,
       }));
 
@@ -95,7 +95,7 @@ describe("webService", () => {
     it("should create a valid delete request", async () => {
       AuthService.mockImplementation(() => ({
         isAuthenticated: () => true,
-        buildAuthUrl: url => url,
+        buildAuthUrl: (url) => url,
         getClientId: () => 42,
       }));
 


### PR DESCRIPTION
# Description

Add scope verification before reset access when admin create user Zoapp/front#114.

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Other (non-breaking change which doesn't match an issue, Non-code related, ...)

# How Has This Been Tested?

Yarn lint & test have been launched.

**Test Configuration**:
* Yarn/npm/nodejs version: v1.12.3/v6.5.0/v8.10.0
* OS version: macOS 10.14.2
* Chrome version: Google Chrome 71.0.3578.98

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas