### PR TITLE
Add access_token on createUser service test scope

### DIFF
--- a/src/services/authService.js
+++ b/src/services/authService.js
@@ -152,12 +152,8 @@ export default class AuthService {
   }
 
   async createUser({ username, email, password, accept }) {
-    if (this.scope === "owner") {
-      const error = new Error("Unauthorized");
-      error.status = 400;
-      throw error;
-    }
-    const url = this.urlBuilder.createUrl("user/");
+    let url = this.urlBuilder.createUrl("user");
+    url = this.buildAuthUrl(url.href);
 
     const body = {
       username,


### PR DESCRIPTION
# Description

Add access_token in url on createUser service call to test scope to unauthorized non admin user.

cf Zoapp/front#114

## Type of change

- [X] Other (non-breaking change which doesn't match an issue, Non-code related, ...)

# How Has This Been Tested?

Yarn test & lint have been launched.

**Test Configuration**:
* Yarn/npm/nodejs version: v1.12.3/v6.5.0/v8.10.0
* OS version: macOS 10.14.2
* Chrome version: Google Chrome 71.0.3578.98 

# Checklist:

Please remove lines that are not relevant

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works